### PR TITLE
댕댕백과에서 서치화면 이동시 조회 수정, 상세화면 호출코드 수정

### DIFF
--- a/app/app/src/main/java/com/android/dang/MainActivity.kt
+++ b/app/app/src/main/java/com/android/dang/MainActivity.kt
@@ -145,7 +145,8 @@ class MainActivity : AppCompatActivity(), SearchFragment.DogData, HomeFragment.D
 
     private fun setFragment(frag: Fragment) {
         //디테일은 서치 유지하면서 붙이기 위해서 add로 변경
-        supportFragmentManager.beginTransaction().add(R.id.fragment_view, frag)
+        //롤백 상세 좋아요 선택 후 돌아가면 화면 갱신이 뷰리스토어를 기반으로 두고 있어서 롤백
+        supportFragmentManager.beginTransaction().replace(R.id.fragment_view, frag)
             .setReorderingAllowed(true).addToBackStack(null).commit()
     }
 

--- a/app/app/src/main/java/com/android/dang/search/SearchFragment.kt
+++ b/app/app/src/main/java/com/android/dang/search/SearchFragment.kt
@@ -85,11 +85,12 @@ class SearchFragment : Fragment(R.layout.fragment_search), SearchAdapter.ItemCli
         if(!isActionBreedName()) {
             //댕댕백과 품종이 없는 경우, 이전 검색결과 남기지 않도록 초기화했어요.(필요없으면 수정하세요)
             //상세화면 갔다 검색화면으로 돌아오면 검색이 다시 그려지지 않도록 했습니다.
-            typeOne = 1
-            kindNumber = ""
-            binding.searchEdit.post {
-                binding.searchEdit.setText("")
-            }
+            //롤백 상세 좋아요 선택 후 돌아가면 화면 갱신이 뷰리스토어를 기반으로 두고 있어서 롤백
+//            typeOne = 1
+//            kindNumber = ""
+//            binding.searchEdit.post {
+//                binding.searchEdit.setText("")
+//            }
         }
 
         recentViewModel.recentReset()

--- a/app/app/src/main/java/com/android/dang/search/SearchFragment.kt
+++ b/app/app/src/main/java/com/android/dang/search/SearchFragment.kt
@@ -69,7 +69,7 @@ class SearchFragment : Fragment(R.layout.fragment_search), SearchAdapter.ItemCli
     override fun onAttach(context: Context) {
         super.onAttach(context)
         mContext = context
-        kindData()
+//        kindData()
         Log.d("autoWordList1", "${autoWordList.size}")
     }
 
@@ -77,21 +77,12 @@ class SearchFragment : Fragment(R.layout.fragment_search), SearchAdapter.ItemCli
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentSearchBinding.bind(view)
 
-
-
+        kindData() //attach하는 시점보다는 UI그리는 시점에서 로딩바로 막아주는게 좋은 듯
         initView()
         viewModel()
 
         //댕댕백과에서 품종이름이 넘어오면 설정
-        arguments?.getString(SELECTED_BREED_NAME)?.let {
-            Log.d("TEST", "댕댕백과에서 전달받은 품종 : $it")
-            kindNumber = ""
-            searchViewModel.clearSearches() //기존검색결과를 중복호출하여 추가
-            binding.searchEdit.post {
-                setEditAndSearchData(it)
-                arguments?.remove(SELECTED_BREED_NAME)
-            }
-        } ?: run {
+        if(!isActionBreedName()) {
             //댕댕백과 품종이 없는 경우, 이전 검색결과 남기지 않도록 초기화했어요.(필요없으면 수정하세요)
             //상세화면 갔다 검색화면으로 돌아오면 검색이 다시 그려지지 않도록 했습니다.
             typeOne = 1
@@ -523,6 +514,12 @@ class SearchFragment : Fragment(R.layout.fragment_search), SearchAdapter.ItemCli
     }
 
     private fun kindData() {
+        //해쉬맵에 카인드정보가 있으면 API호출하지 않음
+        if (hashMap.isNotEmpty()) return
+        //카인드 API호출할 때 로딩바 추가해서 다른 작업이 되지 않도록 표시
+        binding.progressDictionary.post {
+            binding.progressDictionary.visibility = View.VISIBLE
+        }
         api.kindSearch(
             Constants.AUTH_HEADER
         ).enqueue(object : Callback<Kind?> {
@@ -536,13 +533,16 @@ class SearchFragment : Fragment(R.layout.fragment_search), SearchAdapter.ItemCli
                         hashMap[kind] = kindNumber
                         autoWordList.add(kind)
                     }
+                    isActionBreedName() //카인드가 없는데 댕댕백과에서 요청이 오면 카인드 목록 받은 후에 검색
                 } else {
                     Log.e("api", "Error: ${response.errorBody()}")
                 }
+                binding.progressDictionary.visibility = View.GONE
             }
 
             override fun onFailure(call: Call<Kind?>, t: Throwable) {
                 Log.e("#api1", "실패: ${t.message}")
+                binding.progressDictionary.visibility = View.GONE
             }
 
         })
@@ -622,4 +622,22 @@ class SearchFragment : Fragment(R.layout.fragment_search), SearchAdapter.ItemCli
             searchAdapter.searchNew()
         }
     }
+
+    /**
+     * 댕댕백과에서 넘어온 품종 세팅 및 검색 수행 함수
+     *
+     * @return 품종이름이 있으면 true / 없으면 false
+     */
+    private fun isActionBreedName(): Boolean = arguments?.getString(SELECTED_BREED_NAME)?.let {
+        Log.d("TEST", "댕댕백과에서 전달받은 품종 : $it")
+        kindNumber = ""
+        searchViewModel.clearSearches() //기존검색결과가 보여서 클리어
+        if (hashMap.isNotEmpty()) {
+            binding.searchEdit.post {
+                setEditAndSearchData(it)
+                arguments?.remove(SELECTED_BREED_NAME)
+            }
+        }
+        true
+    } ?: false
 }

--- a/app/app/src/main/res/layout/fragment_dog_detail.xml
+++ b/app/app/src/main/res/layout/fragment_dog_detail.xml
@@ -6,9 +6,6 @@
     android:layout_height="match_parent"
     android:layout_marginStart="15dp"
     android:layout_marginEnd="15dp"
-    android:background="@color/white"
-    android:clickable="true"
-    android:focusable="true"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <ImageView
         android:id="@+id/dog_img"


### PR DESCRIPTION
## 구현내용
- 카인드 데이터 들어오는 것 확인 후 검색 코드 적용하도록 하였습니다.
- 상세페이지에서 찜을 갱신하고 다른 화면에 가면 갱신이 안되어 있어서 수정했습니다.  (add->replace) 원복
- 카인드 데이타가 있으면 API를 추가 호출하지 않도록 처리

## 주요 변동 파일
- MainActivity.kt
- SearchFragment.kt
- fragment_dog_detail.xml